### PR TITLE
Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.pkl
 data/
+*.egg-info

--- a/folk_rnn.py
+++ b/folk_rnn.py
@@ -68,7 +68,7 @@ class Folk_RNN:
         l_reshp = ReshapeLayer(main_layers[-1], (-1, rnn_size))
         l_out = DenseLayer(l_reshp, num_units=vocab_size, nonlinearity=lasagne.nonlinearities.identity)
         predictions = T.nnet.softmax(lasagne.layers.get_output(l_out, deterministic=True)[-1, :] / temperature)[0]
-        lasagne.layers.set_all_param_values(l_out, param_values) # Toby Question: does this affect the result?
+        lasagne.layers.set_all_param_values(l_out, param_values)
         
         if self.debug:
             all_layes = lasagne.layers.get_all_layers(l_out)

--- a/folk_rnn.py
+++ b/folk_rnn.py
@@ -1,0 +1,103 @@
+import theano
+import lasagne
+import os
+import sys
+import time
+import importlib
+if sys.version_info < (3,0):
+    import cPickle as pickle
+else:
+    import pickle
+import numpy as np
+import theano.tensor as T
+from lasagne.layers import *
+
+class Folk_RNN:
+    """
+    Folk music style modelling using LSTMs
+    """
+    
+    debug = False
+    
+    def __init__(self, 
+                 token2idx, 
+                 param_values,
+                 num_layers,
+                 rnn_size, 
+                 grad_clipping,
+                 dropout=0, 
+                 embedding_size=None, 
+                 random_number_generator_seed=42, 
+                 temperature=1.0
+                 ):
+        theano.config.floatX = 'float64'
+        vocab_size = len(token2idx)
+        one_hot = embedding_size is None
+        
+        self.token2idx = token2idx
+        self.idx2token = dict((v, k) for k, v in self.token2idx.iteritems())
+        self.vocab_idxs = np.arange(vocab_size)
+        self.start_idx, self.end_idx = self.token2idx['<s>'], self.token2idx['</s>']
+        self.rng = np.random.RandomState(random_number_generator_seed)
+        self.seed_tune()
+       
+        if self.debug:
+            print('Building the model')
+        
+        x = T.imatrix('x')
+        
+        l_inp = InputLayer((1, None), input_var=x)
+        
+        W_emb = np.eye(vocab_size, dtype='float32') if one_hot else lasagne.init.Orthogonal()
+        emb_output_size = vocab_size if one_hot else embedding_size
+        l_emb = EmbeddingLayer(l_inp, input_size=vocab_size, output_size=emb_output_size, W=W_emb)
+        
+        main_layers = []
+        for _ in xrange(num_layers):
+            if not main_layers:
+                main_layers.append(LSTMLayer(l_emb, num_units=rnn_size,
+                                             peepholes=False,
+                                             grad_clipping=grad_clipping))
+            else:
+                main_layers.append(LSTMLayer(main_layers[-1], num_units=rnn_size,
+                                             peepholes=False,
+                                             grad_clipping=grad_clipping))
+            if dropout > 0:
+                main_layers.append(DropoutLayer(main_layers[-1], p=dropout))
+        
+        l_reshp = ReshapeLayer(main_layers[-1], (-1, rnn_size))
+        l_out = DenseLayer(l_reshp, num_units=vocab_size, nonlinearity=lasagne.nonlinearities.identity)
+        predictions = T.nnet.softmax(lasagne.layers.get_output(l_out, deterministic=True)[-1, :] / temperature)[0]
+        lasagne.layers.set_all_param_values(l_out, param_values) # Toby Question: does this affect the result?
+        
+        if self.debug:
+            all_layes = lasagne.layers.get_all_layers(l_out)
+            for layer in all_layes:
+                print(layer.__class__.__name__)
+                for p in layer.get_params():
+                    print(p.get_value().shape)
+            print('number of parameters: ', lasagne.layers.count_params(l_out))
+        
+        self.predict = theano.function([x], predictions)
+    
+    def seed_tune(self, seed_tune_abc=None):
+        """
+        Sets the seed of the tune
+        """
+        self.tune = [self.start_idx]
+        if seed_tune_abc is not None:
+            self.tune += [self.token2idx[x] for x in seed_tune_abc.split(' ')]
+    
+    def compose_tune(self):
+        """
+        Composes tune and returns it as abc notation
+        """
+        tune = list(self.tune)
+        while tune[-1] != self.end_idx:
+            next_itoken = self.rng.choice(self.vocab_idxs, p=self.predict(np.array([tune], dtype='int32')))
+            tune.append(next_itoken)
+        return '{}\n{}\n{}\n'.format(
+            self.idx2token[tune[1]],
+            self.idx2token[tune[2]],
+            ' '.join(self.idx2token[x] for x in tune[3:-1]),
+            )

--- a/sample_rnn.py
+++ b/sample_rnn.py
@@ -55,5 +55,12 @@ folk_rnn = Folk_RNN(
     )
 folk_rnn.seed_tune(seed)
 for i in xrange(ntunes):
-    print(folk_rnn.compose_tune())
+    tune = 'X:{}\n{}\n'.format(i, folk_rnn.compose_tune())
+    if args.terminal:
+        print(tune)
+    else:
+        with open(target_path, 'a+') as f:
+            f.write(tune)
+        print('Saved to {}'.format(target_path))
+    
     

--- a/sample_rnn.py
+++ b/sample_rnn.py
@@ -14,8 +14,8 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument('metadata_path')
-parser.add_argument('--rng_seed', type=int, default=42)
-parser.add_argument('--temperature', type=float, default=1.0)
+parser.add_argument('--rng_seed', type=int)
+parser.add_argument('--temperature', type=float)
 parser.add_argument('--ntunes', type=int, default=1)
 parser.add_argument('--seed')
 parser.add_argument('--terminal', action="store_true")
@@ -27,6 +27,8 @@ rng_seed = args.rng_seed
 temperature = args.temperature
 ntunes = args.ntunes
 seed = args.seed
+
+print('seed', seed)
 
 with open(metadata_path) as f:
     metadata = pickle.load(f)

--- a/sample_rnn.py
+++ b/sample_rnn.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 
-import theano
-import lasagne
 import os
 import sys
 import time
@@ -10,12 +8,8 @@ if sys.version_info < (3,0):
     import cPickle as pickle
 else:
     import pickle
-import numpy as np
-import theano.tensor as T
-from lasagne.layers import *
 
-theano.config.floatX = 'float64'
-
+from folk_rnn import Folk_RNN
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -45,79 +39,21 @@ if not os.path.isdir('samples'):
 target_path = "samples/%s-s%d-%.2f-%s.txt" % (
     metadata['experiment_id'], rng_seed, temperature, time.strftime("%Y%m%d-%H%M%S", time.localtime()))
 
-token2idx = metadata['token2idx']
-idx2token = dict((v, k) for k, v in token2idx.iteritems())
-vocab_size = len(token2idx)
+if config.one_hot:
+    config.embedding_size = None
 
-print('Building the model')
-x = T.imatrix('x')
-
-l_inp = InputLayer((1, None), input_var=x)
-
-W_emb = np.eye(vocab_size, dtype='float32') if config.one_hot else lasagne.init.Orthogonal()
-emb_output_size = vocab_size if config.one_hot else config.embedding_size
-l_emb = EmbeddingLayer(l_inp, input_size=vocab_size, output_size=emb_output_size, W=W_emb)
-
-main_layers = []
-for _ in xrange(config.num_layers):
-    if not main_layers:
-        main_layers.append(LSTMLayer(l_emb, num_units=config.rnn_size,
-                                     peepholes=False,
-                                     grad_clipping=config.grad_clipping))
-    else:
-        main_layers.append(LSTMLayer(main_layers[-1], num_units=config.rnn_size,
-                                     peepholes=False,
-                                     grad_clipping=config.grad_clipping))
-    if config.dropout > 0:
-        main_layers.append(DropoutLayer(main_layers[-1], p=config.dropout))
-
-l_reshp = ReshapeLayer(main_layers[-1], (-1, config.rnn_size))
-l_out = DenseLayer(l_reshp, num_units=vocab_size, nonlinearity=lasagne.nonlinearities.identity)
-predictions = T.nnet.softmax(lasagne.layers.get_output(l_out, deterministic=True)[-1, :] / temperature)[0]
-
-all_params = lasagne.layers.get_all_params(l_out)
-lasagne.layers.set_all_param_values(l_out, metadata['param_values'])
-
-all_layes = lasagne.layers.get_all_layers(l_out)
-for layer in all_layes:
-    print(layer.__class__.__name__)
-    for p in layer.get_params():
-        print(p.get_value().shape)
-print('number of parameters: ', lasagne.layers.count_params(l_out))
-
-predict = theano.function([x], predictions)
-
-start_idx, end_idx = token2idx['<s>'], token2idx['</s>']
-
-rng = np.random.RandomState(rng_seed)
-vocab_idxs = np.arange(vocab_size)
-
-# Converting the seed passed as an argument into a list of idx
-seed_sequence = [start_idx]
-if seed is not None:
-    for token in seed.split(' '):
-        seed_sequence.append(token2idx[token])
-
+folk_rnn = Folk_RNN(
+    metadata['token2idx'],
+    metadata['param_values'], 
+    config.num_layers, 
+    config.rnn_size,
+    config.grad_clipping,
+    config.dropout, 
+    config.embedding_size, 
+    rng_seed, 
+    temperature
+    )
+folk_rnn.seed_tune(seed)
 for i in xrange(ntunes):
-    sequence = seed_sequence[:]
-    while sequence[-1] != end_idx:
-        next_itoken = rng.choice(vocab_idxs, p=predict(np.array([sequence], dtype='int32')))
-        sequence.append(next_itoken)
-
-    abc_tune = [idx2token[j] for j in sequence[1:-1]]
-    if not args.terminal:
-        f = open(target_path, 'a+')
-        f.write('X:' + repr(i) + '\n')
-        f.write(abc_tune[0] + '\n')
-        f.write(abc_tune[1] + '\n')
-        f.write(' '.join(abc_tune[2:]) + '\n\n')
-        f.close()
-    else:
-        print('X:' + repr(i))
-        print(abc_tune[0])
-        print(abc_tune[1])
-        print(' '.join(abc_tune[2:]) + '\n')
-
-
-if not args.terminal:
-    print('Saved to '+target_path)
+    print(folk_rnn.compose_tune())
+    

--- a/sample_rnn.py
+++ b/sample_rnn.py
@@ -107,13 +107,13 @@ for i in xrange(ntunes):
     abc_tune = [idx2token[j] for j in sequence[1:-1]]
     if not args.terminal:
         f = open(target_path, 'a+')
-	f.write('X:' + repr(i) + '\n')
+        f.write('X:' + repr(i) + '\n')
         f.write(abc_tune[0] + '\n')
         f.write(abc_tune[1] + '\n')
         f.write(' '.join(abc_tune[2:]) + '\n\n')
         f.close()
     else:
-	print('X:' + repr(i))
+        print('X:' + repr(i))
         print(abc_tune[0])
         print(abc_tune[1])
         print(' '.join(abc_tune[2:]) + '\n')

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,113 @@
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='sample',
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='1.2.0',
+
+    description='A sample Python project',
+    long_description=long_description,
+
+    # The project's main homepage.
+    url='https://github.com/pypa/sampleproject',
+
+    # Author details
+    author='The Python Packaging Authority',
+    author_email='pypa-dev@googlegroups.com',
+
+    # Choose your license
+    license='MIT',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 3 - Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+
+    # What does your project relate to?
+    keywords='sample setuptools development',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+
+    # Alternatively, if you want to distribute just a my_module.py, uncomment
+    # this:
+    #   py_modules=["my_module"],
+
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=['peppercorn'],
+
+    # List additional groups of dependencies here (e.g. development
+    # dependencies). You can install these using the following syntax,
+    # for example:
+    # $ pip install -e .[dev,test]
+    extras_require={
+        'dev': ['check-manifest'],
+        'test': ['coverage'],
+    },
+
+    # If there are data files included in your packages that need to be
+    # installed, specify them here.  If using Python 2.6 or less, then these
+    # have to be included in MANIFEST.in as well.
+    package_data={
+        'sample': ['package_data.dat'],
+    },
+
+    # Although 'package_data' is the preferred approach, in some case you may
+    # need to place data files outside of your packages. See:
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
+    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+    data_files=[('my_data', ['data/data_file'])],
+
+    # To provide executable scripts, use entry points in preference to the
+    # "scripts" keyword. Entry points provide cross-platform support and allow
+    # pip to create the appropriate form of executable for the target platform.
+    entry_points={
+        'console_scripts': [
+            'sample=sample:main',
+        ],
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,3 @@
-"""A setuptools based setup module.
-
-See:
-https://packaging.python.org/en/latest/distributing.html
-https://github.com/pypa/sampleproject
-"""
-
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
 # To use a consistent encoding
@@ -18,22 +11,22 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='sample',
+    name='folk-rnn',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0',
+    version='0.9.0',
 
-    description='A sample Python project',
+    description='Folk music style modelling using LSTMs',
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/pypa/sampleproject',
+    url='https://github.com/IraKorshunova/folk-rnn',
 
     # Author details
-    author='The Python Packaging Authority',
-    author_email='pypa-dev@googlegroups.com',
+    author='',
+    author_email='',
 
     # Choose your license
     license='MIT',
@@ -47,24 +40,19 @@ setup(
         'Development Status :: 3 - Alpha',
 
         # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
+        'Intended Audience :: Science/Research',
 
         # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: MIT License',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
     ],
 
     # What does your project relate to?
-    keywords='sample setuptools development',
+    keywords='folk music lstm rnn',
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
@@ -78,36 +66,32 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['peppercorn'],
+    install_requires=[
+        'theano',
+        'lasagne',
+        ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:
     # $ pip install -e .[dev,test]
-    extras_require={
-        'dev': ['check-manifest'],
-        'test': ['coverage'],
-    },
+    extras_require={},
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
-    package_data={
-        'sample': ['package_data.dat'],
-    },
+    package_data={},
 
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[('my_data', ['data/data_file'])],
+    data_files=[],
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
-        'console_scripts': [
-            'sample=sample:main',
-        ],
+        'console_scripts': [],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'theano',
+        'theano<0.8',
         'lasagne',
         ],
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
     ],
 
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,6 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-here = path.abspath(path.dirname(__file__))
-
-# Get the long description from the README file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
-
 setup(
     name='folk-rnn',
 
@@ -19,7 +13,7 @@ setup(
     version='0.9.0',
 
     description='Folk music style modelling using LSTMs',
-    long_description=long_description,
+    long_description='Long version to be converted from README markdown to ReStructuredText if this ever is uploaded to PyPi. https://stackoverflow.com/a/26737672',
 
     # The project's main homepage.
     url='https://github.com/IraKorshunova/folk-rnn',


### PR DESCRIPTION
This adds packaging information to folk_rnn, and extracts the core functionality of folk_rnn into a class. This is in aid of creating a folk_rnn task as part of a web-app, which will require installation on the server and a programmatic interface to the folk_rnn functionality. 

e.g. https://github.com/tobyspark/folk-rnn-webapp/commit/d60f73a6baa30b5c4eca329b37a4b52c9ecc9936

The packaging is not exhaustive. It's certainly not enough to upload to PyPi, which would be desirable to ensure version control on import to production servers. This is the minimum viable to be able to `pip install -e .` on a clone of the repo, e.g. https://github.com/tobyspark/folk-rnn-webapp/commit/6db57e2095342c2f93852c35d0d83f22bac71b92

This refactored codebase appears to produce identical output – see note in https://github.com/tobyspark/folk-rnn/commit/381184a2d6659a47520cedd6d4dfa7bb1c5189f7 – but no guarantees are made!